### PR TITLE
fix: Improve transaction categorization logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# Bot-flow-cash
+# Bot Pencatat Keuangan Pribadi
+
+Bot Telegram cerdas untuk mencatat arus kas (pemasukan dan pengeluaran) harian Anda menggunakan pemrosesan bahasa alami yang didukung oleh Google Gemini AI dan database Supabase.
+
+## Fitur Utama
+
+-   **Pencatatan Bahasa Alami**: Cukup kirim pesan seperti "Beli kopi susu 25 ribu" atau "Gajian 5 juta" dan biarkan AI yang memprosesnya.
+-   **Ringkasan Harian**: Dapatkan rekapitulasi pemasukan dan pengeluaran untuk tanggal tertentu dengan perintah `/day DD-MM-YY`.
+-   **Ringkasan Bulanan**: Dapatkan rekapitulasi untuk bulan tertentu dengan perintah `/month MM-YY`.
+-   **Multi-Pengguna**: Data setiap pengguna disimpan secara terpisah dan aman berdasarkan ID unik Telegram.
+
+## Teknologi yang Digunakan
+
+-   **Python**: Bahasa utama pengembangan bot.
+-   **python-telegram-bot**: Library untuk berinteraksi dengan Telegram Bot API.
+-   **Google Gemini AI**: Untuk pemrosesan bahasa alami (NLP) dan ekstraksi data dari teks.
+-   **Supabase**: Sebagai database PostgreSQL cloud untuk menyimpan semua data transaksi.
+
+## Penyiapan dan Instalasi
+
+Untuk menjalankan bot ini di lingkungan lokal Anda, ikuti langkah-langkah berikut:
+
+**1. Clone Repositori**
+```bash
+git clone https://github.com/asdi-id/Bot-flow-cash.git
+cd Bot-flow-cash
+```
+
+**2. Buat Virtual Environment (Direkomendasikan)**
+```bash
+python -m venv venv
+source venv/bin/activate  # Di Windows, gunakan `venv\Scripts\activate`
+```
+
+**3. Install Dependensi**
+Pastikan semua library yang dibutuhkan terinstal.
+```bash
+pip install -r requirements.txt
+```
+
+**4. Siapkan Database Supabase**
+-   Buat proyek baru di [Supabase](https://supabase.com).
+-   Di dalam proyek Anda, navigasikan ke **SQL Editor**.
+-   Salin seluruh konten dari file `database/schema.sql` dan jalankan di editor untuk membuat tabel `transactions`.
+
+**5. Konfigurasi Environment Variables**
+-   Salin file `.env.example` menjadi file baru bernama `.env`.
+-   Isi semua variabel di dalam file `.env` dengan kredensial Anda:
+    -   `TELEGRAM_BOT_TOKEN`: Token bot dari BotFather di Telegram.
+    -   `GEMINI_API_KEY`: Kunci API Anda dari Google AI Studio.
+    -   `SUPABASE_URL`: URL proyek Supabase Anda (ada di Project Settings > API).
+    -   `SUPABASE_KEY`: Kunci `anon` `public` proyek Supabase Anda (ada di Project Settings > API).
+
+**6. Jalankan Bot**
+```bash
+python bot.py
+```
+Bot Anda sekarang sudah aktif dan siap menerima pesan!
+
+## Cara Penggunaan
+
+-   **Mencatat Transaksi**:
+    -   Kirim pesan: `Makan siang 20000`
+    -   Kirim pesan: `Dapat bonus 500rb`
+
+-   **Melihat Ringkasan Harian**:
+    -   Kirim perintah: `/day 31-08-25`
+
+-   **Melihat Ringkasan Bulanan**:
+    -   Kirim perintah: `/month 08-25`

--- a/bot.py
+++ b/bot.py
@@ -75,11 +75,21 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         - "amount": angka (integer atau float) dari jumlah transaksi.
         - "description": deskripsi singkat dari transaksi.
 
+        ATURAN PENTING:
+        1.  Prioritaskan "expense" jika ada kata kunci seperti: 'bayar', 'beli', 'biaya', 'untuk', 'kasih', 'keluar', 'jajan'.
+        2.  Prioritaskan "income" jika ada kata kunci seperti: 'dapat', 'terima', 'gaji', 'bonus', 'dari', 'masuk'.
+        3.  Untuk kasus ambigu seperti "uang bulanan", jika tidak ada kata kunci lain, anggap itu sebagai "expense".
+
         Jika teks tidak terlihat seperti transaksi keuangan, kembalikan JSON dengan "type": "none".
 
-        Contoh:
+        Contoh Standar:
         - Teks: "Makan siang nasi padang 25000" -> {{"type": "expense", "amount": 25000, "description": "Makan siang nasi padang"}}
         - Teks: "dapat bonus akhir tahun 1.500.000" -> {{"type": "income", "amount": 1500000, "description": "Dapat bonus akhir tahun"}}
+
+        Contoh Penanganan Ambiguitas:
+        - Teks: "uang bulanan 1.600.000" -> {{"type": "expense", "amount": 1600000, "description": "Uang bulanan"}}
+        - Teks: "bayar uang bulanan 1.600.000" -> {{"type": "expense", "amount": 1600000, "description": "Bayar uang bulanan"}}
+        - Teks: "dapat uang bulanan dari ortu 500rb" -> {{"type": "income", "amount": 500000, "description": "Dapat uang bulanan dari ortu"}}
         - Teks: "halo apa kabar" -> {{"type": "none", "amount": 0, "description": "Bukan transaksi"}}
 
         Hanya kembalikan JSON, tanpa teks tambahan atau markdown.


### PR DESCRIPTION
This commit refines the prompt sent to the Gemini AI to better handle ambiguous transaction descriptions.

The new prompt includes specific rules and examples for keywords related to income (e.g., "dapat", "gaji") and expenses (e.g., "bayar", "beli"). It also sets a default categorization for common ambiguous phrases like "uang bulanan" to be treated as an expense unless specified otherwise.

This change directly addresses the issue where ambiguous user input was being incorrectly categorized.