### PR TITLE
fix: Correct ConversationHandler logic for edit feature

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -418,9 +418,14 @@ def main() -> None:
 
     # Buat ConversationHandler untuk mengelola state
     conv_handler = ConversationHandler(
-        entry_points=[MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message)],
+        entry_points=[
+            MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message),
+            CallbackQueryHandler(button_handler) # Tombol sekarang bagian dari percakapan
+        ],
         states={
-            AWAITING_EDIT_INPUT: [MessageHandler(filters.TEXT & ~filters.COMMAND, handle_edit_input)],
+            AWAITING_EDIT_INPUT: [
+                MessageHandler(filters.TEXT & ~filters.COMMAND, handle_edit_input)
+            ],
         },
         fallbacks=[
             CommandHandler("start", start),
@@ -430,11 +435,8 @@ def main() -> None:
         ],
     )
 
-    # Daftarkan handler
+    # Daftarkan handler utama (ConversationHandler)
     application.add_handler(conv_handler)
-    application.add_handler(CallbackQueryHandler(button_handler))
-    # Tambahkan handler lain yang tidak termasuk dalam conversation di sini jika ada
-    # application.add_handler(CommandHandler("start", start)) # Contoh jika start di luar conversation
 
 
     # Mulai bot (polling)


### PR DESCRIPTION
This commit fixes a bug where the bot would incorrectly process an edit as a new transaction.

The root cause was that the `CallbackQueryHandler` (for button presses) was outside the `ConversationHandler`, so the state change to "awaiting edit" was not being tracked correctly by the conversation manager.

The fix moves the `CallbackQueryHandler` into the `entry_points` of the `ConversationHandler`. This ensures that the button press is part of the conversation flow, allowing the state to be set and persisted correctly, which in turn routes the user's subsequent text message to the proper `handle_edit_input` function.