### PR TITLE
fix: Pin zhipuai version to resolve ImportError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ python-dotenv
 matplotlib
 
 # For Zhipu AI (GLM) Failover
-zhipuai
+zhipuai>=2.1.0


### PR DESCRIPTION
This commit fixes an `ImportError` for the `zhipuai` library by specifying a minimum version in `requirements.txt`.

The error `cannot import name 'ZhipuAI' from 'zhipuai'` was caused by users potentially having an older version of the package installed. By changing the requirement to `zhipuai>=2.1.0`, we ensure that a version with the correct class name is installed, resolving the bug.