### PR TITLE
fix(voice): Use 'contents' keyword for in-memory file upload

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -73,7 +73,8 @@ async def handle_voice_message(update: Update, context: ContextTypes.DEFAULT_TYP
 
         # Upload file audio ke Gemini
         # Gemini API dapat menangani berbagai format, .oga (Opus) dari Telegram didukung
-        audio_file = genai.upload_file(file=voice_data, mime_type=voice.mime_type)
+        # Argumen yang benar untuk data dari memori adalah `contents`.
+        audio_file = genai.upload_file(contents=voice_data, mime_type=voice.mime_type)
 
         # Minta transkripsi dari Gemini
         prompt = "Transkripsikan audio ini ke dalam teks bahasa Indonesia."


### PR DESCRIPTION
This commit corrects the `genai.upload_file` call in the `handle_voice_message` function.

Previous attempts using `file_path` and `file` as keyword arguments both failed, indicating a mismatch with the library's API for in-memory data. Based on further analysis and documentation, the correct keyword argument for uploading a `BytesIO` object is `contents`.

This change replaces the incorrect argument with `contents=...`, which is expected to resolve the `TypeError` and make the voice message transcription feature fully functional.